### PR TITLE
ci: add github actions for testing and releasing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @entur/terraform-module-reviewers

--- a/.github/workflows/pr-tests-terraform.yml
+++ b/.github/workflows/pr-tests-terraform.yml
@@ -1,0 +1,16 @@
+name: Call Terraform Tests, Docs & Compliance
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  tf-tests:
+    uses: entur/gh-workflows/.github/workflows/pr-tests-terraform.yml@main
+    with:
+      module_dirs: '["./modules/redis"]'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,15 @@
+name: Call Validate PR
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - edited
+
+jobs:
+  validate-pr:
+    uses: entur/gh-workflows/.github/workflows/pr-validation.yml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,15 @@
+name: Call Release Please
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  tf-tests:
+    uses: entur/gh-workflows/.github/workflows/release-please.yml@main
+    with:
+      release_type: terraform-module
+      version_bumped_files: |
+        README.md
+        examples/minimal/main.tf


### PR DESCRIPTION
Adds default github actions for Entur terraform modules.
* Action which runs terraform validation and tests.
* Action which checks if the PR name follows conventional commits.
* Action which uses release-please for releasing new module versions.