### PR TITLE
docs: update docs and example to use release-please version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terraform module(s) for creating Google Cloud Memorystore instances following Entur's conventions
 
-Modules for provisioning memorystore instances on Google Cloud Platform.
+Modules for provisioning Memorystore instances on Google Cloud Platform.
 
 ## Redis module
 
@@ -10,26 +10,23 @@ A Redis module that uses the [init module](https://github.com/entur/terraform-go
 
 [Examples](examples)
 
-## Usage instructions
+## Getting started
+
+<!-- ci: x-release-please-start-version -->
+### Example using the latest release
+
+```
+module "redis" {
+  source = "github.com/entur/terraform-google-memorystore//modules/redis?ref=v0.1.0"
+  ...
+}
+```
+<!-- ci: x-release-please-end -->
+
+See the `README.md` under each module's subfolder for a list of supported inputs and outputs. For examples showing how they're implemented, check the [examples](examples) subfolder.
 
 ### Version constraints
 
-You can control the version of a module dependency by adding `?ref=TAG` at the end of the source argument. This is highly recommended. You can find a list of available versions [here](https://github.com/entur/terraform-google-memorystore/releases).
-
-```
-module "redis" {
-  source = "github.com/entur/terraform-google-memorystore//modules/redis?ref=vVERSION"
-  ...
-}
-```
+You can control the version of a module dependency by adding `?ref=TAG` at the end of the source argument, as shown in the example above. This is highly recommended. You can find a list of available versions [here](https://github.com/entur/terraform-google-memorystore/releases).
 
 Dependency automation tools such as Renovate Bot will be able to discover new releases and suggest updates automatically.
-
-#### Example
-
-```
-module "redis" {
-  source = "github.com/entur/terraform-google-memorystore//modules/redis?ref=v1.0.0"
-  ...
-}
-```

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -2,16 +2,14 @@ module "init" {
   # This is an example only; if you're adding this block to a live configuration,
   # make sure to use the latest release of the init module, found here:
   # https://github.com/entur/terraform-google-init/releases
-  source      = "github.com/entur/terraform-google-init//modules/init?ref=v1.1.0"
+  source      = "github.com/entur/terraform-google-init//modules/init?ref=v0.2.1"
   app_id      = "tfmodules"
   environment = "dev"
 }
 
+# ci: x-release-please-start-version
 module "redis" {
-  # This is for local reference only; if you're using this module as a published
-  # module from GitHub, the 'source' parameter must refer to it's public location.
-  # See README.md for instructions.
-  # source     = "github.com/entur/terraform-google-memorystore//modules/redis?ref=vVERSION"
-  source     = "../../modules/redis"
-  init       = module.init
+  source = "github.com/entur/terraform-google-memorystore//modules/redis?ref=v0.1.0"
+  init   = module.init
 }
+# ci: x-release-please-end


### PR DESCRIPTION
Updates the readme and example to use release-please for automatic version bump.
Updates usage of the init module in the example to account for the reworked release versions.