### PR TITLE
feat: enable read replicas

### DIFF
--- a/modules/redis/README.md
+++ b/modules/redis/README.md
@@ -33,12 +33,14 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_init"></a> [init](#input\_init) | Entur init module output. https://github.com/entur/terraform-gcp-init. Used to determine application name, application project, network project, labels, and resource names. | <pre>object({<br>    app = object({<br>      id         = string<br>      name       = string<br>      owner      = string<br>      project_id = string<br>    })<br>    environment = string<br>    networks = object({<br>      project_id = string<br>      vpc_id     = string<br>    })<br>    labels        = map(string)<br>    is_production = bool<br>  })</pre> | n/a | yes |
 | <a name="input_availability_type"></a> [availability\_type](#input\_availability\_type) | REGIONAL or ZONAL database. | `string` | `"REGIONAL"` | no |
+| <a name="input_enable_replicas"></a> [enable\_replicas](#input\_enable\_replicas) | Enable read replicas | `bool` | `false` | no |
 | <a name="input_generation"></a> [generation](#input\_generation) | Generation of the redis instance. Starts at 1, ends at 999. Will be padded with leading zeros. | `number` | `1` | no |
 | <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The day of the week (MONDAY-SUNDAY), and hour of the day (0-24) in UTC to perform database instance maintenance. This is the start time of the one hour maintinance window. | <pre>object({<br>    day  = string<br>    hour = number<br>  })</pre> | <pre>{<br>  "day": "TUESDAY",<br>  "hour": 0<br>}</pre> | no |
 | <a name="input_memory_size_gb"></a> [memory\_size\_gb](#input\_memory\_size\_gb) | Allocated memory capasitiy for the instance in GB. | `number` | `1` | no |
 | <a name="input_redis_configs"></a> [redis\_configs](#input\_redis\_configs) | The redis configuration flags. | `map(string)` | <pre>{<br>  "activedefrag": "yes",<br>  "maxmemory-policy": "allkeys-lfu"<br>}</pre> | no |
 | <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | The redis version in the form REDIS\_4\_0. | `string` | `"REDIS_4_0"` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region of the redis instance. | `string` | `"europe-west1"` | no |
+| <a name="input_replica_count"></a> [replica\_count](#input\_replica\_count) | The number [1-5] of replica nodes. Defaults to 2. | `number` | `2` | no |
 
 ## Outputs
 

--- a/modules/redis/README.md
+++ b/modules/redis/README.md
@@ -40,7 +40,7 @@ No modules.
 | <a name="input_redis_configs"></a> [redis\_configs](#input\_redis\_configs) | The redis configuration flags. | `map(string)` | <pre>{<br>  "activedefrag": "yes",<br>  "maxmemory-policy": "allkeys-lfu"<br>}</pre> | no |
 | <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | The redis version in the form REDIS\_4\_0. | `string` | `"REDIS_4_0"` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region of the redis instance. | `string` | `"europe-west1"` | no |
-| <a name="input_replica_count"></a> [replica\_count](#input\_replica\_count) | The number [1-5] of replica nodes. Defaults to 2. | `number` | `2` | no |
+| <a name="input_replica_count"></a> [replica\_count](#input\_replica\_count) | The number [1-5] of replica nodes. Defaults to 1. | `number` | `1` | no |
 
 ## Outputs
 

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -1,8 +1,7 @@
 locals {
-  generation         = format("%03d", var.generation)
-  connect_mode       = "PRIVATE_SERVICE_ACCESS"
-  tier               = "STANDARD_HA"
-  read_replicas_mode = "READ_REPLICAS_DISABLED"
+  generation   = format("%03d", var.generation)
+  connect_mode = "PRIVATE_SERVICE_ACCESS"
+  tier         = "STANDARD_HA"
 }
 
 resource "google_redis_instance" "main" {
@@ -17,7 +16,8 @@ resource "google_redis_instance" "main" {
 
   connect_mode       = local.connect_mode
   authorized_network = var.init.networks.vpc_id
-  read_replicas_mode = local.read_replicas_mode
+  read_replicas_mode = var.enable_replicas ? "READ_REPLICAS_ENABLED" : "READ_REPLICAS_DISABLED"
+  replica_count      = var.replica_count
 
   labels = var.init.labels
 
@@ -41,7 +41,9 @@ resource "kubernetes_config_map" "main_redis_connection" {
     labels    = var.init.labels
   }
   data = {
-    REDIS_HOST = google_redis_instance.main.host
-    REDIS_PORT = google_redis_instance.main.port
+    REDIS_HOST      = google_redis_instance.main.host
+    REDIS_PORT      = google_redis_instance.main.port
+    REDIS_READ_HOST = google_redis_instance.main.read_endpoint
+    REDIS_READ_PORT = google_redis_instance.main.read_endpoint_port
   }
 }

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -91,9 +91,9 @@ variable "enable_replicas" {
 }
 
 variable "replica_count" {
-  description = "The number [1-5] of replica nodes. Defaults to 2."
+  description = "The number [1-5] of replica nodes. Defaults to 1."
   type        = number
-  default     = 2
+  default     = 1
   validation {
     condition     = var.replica_count >= 1 && var.replica_count <= 5
     error_message = "Memory size must be a whole number, between 1 and 5 inclusive."

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -83,3 +83,19 @@ variable "redis_configs" {
     maxmemory-policy = "allkeys-lfu"
   }
 }
+
+variable "enable_replicas" {
+  description = "Enable read replicas"
+  type        = bool
+  default     = false
+}
+
+variable "replica_count" {
+  description = "The number [1-5] of replica nodes. Defaults to 2."
+  type        = number
+  default     = 2
+  validation {
+    condition     = var.replica_count >= 1 && var.replica_count <= 5
+    error_message = "Memory size must be a whole number, between 1 and 5 inclusive."
+  }
+}


### PR DESCRIPTION
Adds `enable_replicas` and `replica_count` variables.

Additionally, the output connection ConfigMap will have `REDIS_READ_HOST` and `REDIS_READ_PORT`.