### PR TITLE
fix: set replica_count to null if enable_replicas false

### DIFF
--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -17,7 +17,7 @@ resource "google_redis_instance" "main" {
   connect_mode       = local.connect_mode
   authorized_network = var.init.networks.vpc_id
   read_replicas_mode = var.enable_replicas ? "READ_REPLICAS_ENABLED" : "READ_REPLICAS_DISABLED"
-  replica_count      = var.replica_count
+  replica_count      = var.enable_replicas ? var.replica_count : null
 
   labels = var.init.labels
 


### PR DESCRIPTION
```log
INFO   2023-01-13 13:32:12    Error: Error creating Instance: googleapi: Error 400: Setting replica count requires read-replicas-mode to be "READ_REPLICAS_ENABLED"
INFO   2023-01-13 13:32:12    com.google.apps.framework.request.StatusException: <eye3 title='INVALID_ARGUMENT'/> generic::INVALID_ARGUMENT: Setting replica count requires read-replicas-mode to be "READ_REPLICAS_ENABLED"
```