### PR TITLE
feat!: enable auth and update redis version

### DIFF
--- a/.github/workflows/pr-int-test-terraform.yml
+++ b/.github/workflows/pr-int-test-terraform.yml
@@ -3,7 +3,7 @@ name: Terraform Integration Tests
 on:
   pull_request:
     paths:
-      - 'modules/postgresql/**'
+      - 'modules/redis/**'
       - 'test/**'
     branches:
       - master

--- a/examples/minimal_test/main.tf
+++ b/examples/minimal_test/main.tf
@@ -9,7 +9,7 @@ module "init" {
   # This is an example only; if you're adding this block to a live configuration,
   # make sure to use the latest release of the init module, found here:
   # https://github.com/entur/terraform-google-init/releases
-  source      = "github.com/entur/terraform-google-init//modules/init?ref=v0.3.0"
+  source      = "github.com/entur/terraform-google-init//modules/init?ref=v0.3.1"
   app_id      = "tfmodules"
   environment = "dev"
 }
@@ -19,7 +19,7 @@ module "redis" {
   # module from GitHub, the 'source' parameter must refer to it's public location.
   # See README.md for instructions.
   # source     = "github.com/entur/terraform-google-memorystore//modules/redis?ref=vVERSION"
-  source = "../../modules/redis"
-  init   = module.init
+  source     = "../../modules/redis"
+  init       = module.init
   generation = random_integer.random_revision_generation.result
 }

--- a/modules/redis/README.md
+++ b/modules/redis/README.md
@@ -38,6 +38,7 @@ No modules.
 | <a name="input_add_redis_secret_manager_credentials"></a> [add\_redis\_secret\_manager\_credentials](#input\_add\_redis\_secret\_manager\_credentials) | Set to false to not store redis credentials in secret manager | `bool` | `true` | no |
 | <a name="input_availability_type"></a> [availability\_type](#input\_availability\_type) | REGIONAL or ZONAL database. | `string` | `"REGIONAL"` | no |
 | <a name="input_create_kubernetes_resources"></a> [create\_kubernetes\_resources](#input\_create\_kubernetes\_resources) | Optionally disables creating k8s resources -redis-connection and -redis-secret. Can be used to avoid overwriting existing resources on database creation. | `bool` | `true` | no |
+| <a name="input_enable_auth"></a> [enable\_auth](#input\_enable\_auth) | Enable authentication | `bool` | `false` | no |
 | <a name="input_enable_replicas"></a> [enable\_replicas](#input\_enable\_replicas) | Enable read replicas | `bool` | `false` | no |
 | <a name="input_generation"></a> [generation](#input\_generation) | Generation of the redis instance. Starts at 1, ends at 999. Will be padded with leading zeros. | `number` | `1` | no |
 | <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The day of the week (MONDAY-SUNDAY), and hour of the day (0-24) in UTC to perform database instance maintenance. This is the start time of the one hour maintinance window. | <pre>object({<br>    day  = string<br>    hour = number<br>  })</pre> | <pre>{<br>  "day": "TUESDAY",<br>  "hour": 0<br>}</pre> | no |

--- a/modules/redis/README.md
+++ b/modules/redis/README.md
@@ -25,23 +25,29 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_redis_instance.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_instance) | resource |
+| [google_secret_manager_secret.main_redis_secret_credentials](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
+| [google_secret_manager_secret_version.main_redis_secret_credentials_version](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
 | [kubernetes_config_map.main_redis_connection](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
+| [kubernetes_secret.main_redis_secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_init"></a> [init](#input\_init) | Entur init module output. https://github.com/entur/terraform-gcp-init. Used to determine application name, application project, network project, labels, and resource names. | <pre>object({<br>    app = object({<br>      id         = string<br>      name       = string<br>      owner      = string<br>      project_id = string<br>    })<br>    environment = string<br>    networks = object({<br>      project_id = string<br>      vpc_id     = string<br>    })<br>    labels        = map(string)<br>    is_production = bool<br>  })</pre> | n/a | yes |
+| <a name="input_add_redis_secret_manager_credentials"></a> [add\_redis\_secret\_manager\_credentials](#input\_add\_redis\_secret\_manager\_credentials) | Set to false to not store redis credentials in secret manager | `bool` | `true` | no |
 | <a name="input_availability_type"></a> [availability\_type](#input\_availability\_type) | REGIONAL or ZONAL database. | `string` | `"REGIONAL"` | no |
+| <a name="input_create_kubernetes_resources"></a> [create\_kubernetes\_resources](#input\_create\_kubernetes\_resources) | Optionally disables creating k8s resources -redis-connection and -redis-secret. Can be used to avoid overwriting existing resources on database creation. | `bool` | `true` | no |
 | <a name="input_enable_replicas"></a> [enable\_replicas](#input\_enable\_replicas) | Enable read replicas | `bool` | `false` | no |
 | <a name="input_generation"></a> [generation](#input\_generation) | Generation of the redis instance. Starts at 1, ends at 999. Will be padded with leading zeros. | `number` | `1` | no |
 | <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The day of the week (MONDAY-SUNDAY), and hour of the day (0-24) in UTC to perform database instance maintenance. This is the start time of the one hour maintinance window. | <pre>object({<br>    day  = string<br>    hour = number<br>  })</pre> | <pre>{<br>  "day": "TUESDAY",<br>  "hour": 0<br>}</pre> | no |
 | <a name="input_memory_size_gb"></a> [memory\_size\_gb](#input\_memory\_size\_gb) | Allocated memory capasitiy for the instance in GB. | `number` | `1` | no |
-| <a name="input_name_override"></a> [name\_override](#input\_name\_override) | Set to override the default redis name. Follows contentions; setting it to 'foo' in dev will result in the redis being named 'mem-foo-dev-001' (<prefix>-<var.name\_override>-<env>-<generation>). Is also applied to the name of the Kubernetes config map. | `string` | `null` | no |
+| <a name="input_name_override"></a> [name\_override](#input\_name\_override) | Set to override the default redis name. Follows contentions; setting it to 'foo' in dev will result in the redis being named 'mem-foo-dev-001' (<prefix>-<var.name\_override>-<env>-<generation>). Is also applied to the name of the Kubernetes config map and secret. | `string` | `null` | no |
 | <a name="input_redis_configs"></a> [redis\_configs](#input\_redis\_configs) | The redis configuration flags. | `map(string)` | <pre>{<br>  "activedefrag": "yes",<br>  "maxmemory-policy": "allkeys-lfu"<br>}</pre> | no |
-| <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | The redis version in the form REDIS\_4\_0. | `string` | `"REDIS_4_0"` | no |
+| <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | The redis version in the form REDIS\_7\_0. | `string` | `"REDIS_7_0"` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region of the redis instance. | `string` | `"europe-west1"` | no |
 | <a name="input_replica_count"></a> [replica\_count](#input\_replica\_count) | The number [1-5] of replica nodes. Defaults to 1. | `number` | `1` | no |
+| <a name="input_secret_key_prefix"></a> [secret\_key\_prefix](#input\_secret\_key\_prefix) | Key prefix of secret. Ex. {secret\_key\_prefix: FIRST\_} would give keys FIRST\_REDIS\_HOST, FIRST\_REDIS\_PASSWORD and so on | `string` | `""` | no |
 
 ## Outputs
 
@@ -50,4 +56,5 @@ No modules.
 | <a name="output_init"></a> [init](#output\_init) | The init module used in the module. |
 | <a name="output_instance"></a> [instance](#output\_instance) | The redis instance output, as described in https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_instance. |
 | <a name="output_kubernetes_namespace"></a> [kubernetes\_namespace](#output\_kubernetes\_namespace) | Name of the kubernetes namespace where the connection details configmap is deployed. |
+| <a name="output_redis_password"></a> [redis\_password](#output\_redis\_password) | The auth password used to connect to the redis instance |
 <!-- END_TF_DOCS -->

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -19,7 +19,7 @@ resource "google_redis_instance" "main" {
 
   connect_mode       = local.connect_mode
   authorized_network = var.init.networks.vpc_id
-  auth_enabled       = true
+  auth_enabled       = var.enable_auth
   read_replicas_mode = var.enable_replicas ? "READ_REPLICAS_ENABLED" : "READ_REPLICAS_DISABLED"
   replica_count      = var.enable_replicas ? var.replica_count : null
 
@@ -54,7 +54,7 @@ locals {
 }
 locals {
   connection  = var.enable_replicas ? merge(local.primary_connection, local.read_connection) : local.primary_connection
-  credentials = merge(local.connection, local.secret)
+  credentials = var.enable_auth ? merge(local.connection, local.secret) : local.connection
 }
 
 resource "kubernetes_config_map" "main_redis_connection" {
@@ -68,7 +68,7 @@ resource "kubernetes_config_map" "main_redis_connection" {
 }
 
 resource "kubernetes_secret" "main_redis_secret" {
-  count = var.create_kubernetes_resources ? 1 : 0
+  count = var.create_kubernetes_resources && var.enable_auth ? 1 : 0
   metadata {
     name      = "${local.kubernetes_name}-redis-secret"
     namespace = var.init.app.name

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -48,6 +48,9 @@ locals {
   secret = {
     REDIS_PASSWORD = google_redis_instance.main.auth_string
   }
+}
+
+locals {
   credentials = merge(local.connection, local.secret)
 }
 
@@ -89,4 +92,8 @@ resource "google_secret_manager_secret_version" "main_redis_secret_credentials_v
   for_each    = var.add_redis_secret_manager_credentials ? local.credentials : {}
   secret      = google_secret_manager_secret.main_redis_secret_credentials[each.key].id
   secret_data = each.value
+
+  depends_on = [
+    google_secret_manager_secret.main_redis_secret_credentials
+  ]
 }

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -94,6 +94,6 @@ resource "google_secret_manager_secret_version" "main_redis_secret_credentials_v
   secret_data = each.value
 
   depends_on = [
-    google_secret_manager_secret.main_redis_secret_credentials
+    google_redis_instance.main
   ]
 }

--- a/modules/redis/outputs.tf
+++ b/modules/redis/outputs.tf
@@ -1,14 +1,20 @@
 output "init" {
-  value       = var.init
   description = "The init module used in the module."
+  value       = var.init
+}
+
+output "redis_password" {
+  description = "The auth password used to connect to the redis instance"
+  sensitive   = true
+  value       = google_redis_instance.main.auth_string
 }
 
 output "instance" {
-  value       = google_redis_instance.main
   description = "The redis instance output, as described in https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_instance."
+  value       = google_redis_instance.main
 }
 
 output "kubernetes_namespace" {
   description = "Name of the kubernetes namespace where the connection details configmap is deployed."
-  value       = kubernetes_config_map.main_redis_connection.metadata[0].namespace
+  value       = var.create_kubernetes_resources ? kubernetes_config_map.main_redis_connection[0].metadata[0].namespace : null
 }

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -106,6 +106,12 @@ variable "replica_count" {
   }
 }
 
+variable "enable_auth" {
+  description = "Enable authentication"
+  type        = bool
+  default     = false
+}
+
 variable "secret_key_prefix" {
   description = "Key prefix of secret. Ex. {secret_key_prefix: FIRST_} would give keys FIRST_REDIS_HOST, FIRST_REDIS_PASSWORD and so on"
   type        = string

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -18,7 +18,7 @@ variable "init" {
 }
 
 variable "name_override" {
-  description = "Set to override the default redis name. Follows contentions; setting it to 'foo' in dev will result in the redis being named 'mem-foo-dev-001' (<prefix>-<var.name_override>-<env>-<generation>). Is also applied to the name of the Kubernetes config map."
+  description = "Set to override the default redis name. Follows contentions; setting it to 'foo' in dev will result in the redis being named 'mem-foo-dev-001' (<prefix>-<var.name_override>-<env>-<generation>). Is also applied to the name of the Kubernetes config map and secret."
   type        = string
   default     = null
 }
@@ -72,9 +72,9 @@ variable "memory_size_gb" {
 }
 
 variable "redis_version" {
-  description = "The redis version in the form REDIS_4_0."
+  description = "The redis version in the form REDIS_7_0."
   type        = string
-  default     = "REDIS_4_0"
+  default     = "REDIS_7_0"
   validation {
     condition     = can(regex("^REDIS_[3-9]_[0-9X]$", var.redis_version))
     error_message = "Supports redis version 3.2 or higher, in the form REDIS_3_2."
@@ -104,4 +104,22 @@ variable "replica_count" {
     condition     = var.replica_count >= 1 && var.replica_count <= 5
     error_message = "Memory size must be a whole number, between 1 and 5 inclusive."
   }
+}
+
+variable "secret_key_prefix" {
+  description = "Key prefix of secret. Ex. {secret_key_prefix: FIRST_} would give keys FIRST_REDIS_HOST, FIRST_REDIS_PASSWORD and so on"
+  type        = string
+  default     = ""
+}
+
+variable "create_kubernetes_resources" {
+  description = "Optionally disables creating k8s resources -redis-connection and -redis-secret. Can be used to avoid overwriting existing resources on database creation."
+  type        = bool
+  default     = true
+}
+
+variable "add_redis_secret_manager_credentials" {
+  description = "Set to false to not store redis credentials in secret manager"
+  type        = bool
+  default     = true
 }

--- a/test/integration/redis_test.go
+++ b/test/integration/redis_test.go
@@ -30,7 +30,8 @@ func TestRedis(t *testing.T) {
 		assert.Contains(redis.Get("locationId").String(), region, "Memorystore instance's GCE region is valid")
 		assert.Contains(redis.Get("name").String(), instanceName, "Memomystore instance has a valid id")
 		assert.Equal(memorySize, redis.Get("memorySizeGb").Int(), "Memorystore instance has been allocated 1 GB of memory")
-		assert.Equal(redis.Get("authEnabled").String(), "true", "Memoystore instance has auth enabled")
+		// Not applicable for current minimal_test
+		// assert.Equal(redis.Get("authEnabled").String(), "true", "Memoystore instance has auth enabled")
 		assert.Equal(redis.Get("connectMode").String(), "PRIVATE_SERVICE_ACCESS")
 		assert.Equal(redis.Get("redisVersion").String(), "REDIS_7_0")
 	})

--- a/test/integration/redis_test.go
+++ b/test/integration/redis_test.go
@@ -14,7 +14,6 @@ import (
 const exampleDir = "../../examples/minimal_test"
 
 func TestRedis(t *testing.T) {
-
 	const region = "europe-west1"
 	const memorySize int64 = 1
 
@@ -24,15 +23,16 @@ func TestRedis(t *testing.T) {
 
 	// asserts copied from https://github.com/terraform-google-modules/terraform-google-sql-db/blob/master/test/integration/postgresql-public/postgresql_public_test.go
 	cloudRedisT.DefineVerify(func(assert *assert.Assertions) {
-		instance_name := cloudRedisT.GetStringOutput("instance_name")
-		project_id := cloudRedisT.GetStringOutput("project_id")
-		redis := gcloud.Run(t, fmt.Sprintf("redis instances describe %s --project %s --region %s", instance_name, project_id, region))
+		instanceName := cloudRedisT.GetStringOutput("instance_name")
+		projectId := cloudRedisT.GetStringOutput("project_id")
+		redis := gcloud.Run(t, fmt.Sprintf("redis instances describe %s --project %s --region %s", instanceName, projectId, region))
 
 		assert.Contains(redis.Get("locationId").String(), region, "Memorystore instance's GCE region is valid")
-		assert.Contains(redis.Get("name").String(), instance_name, "Memomystore instance has a valid id")
+		assert.Contains(redis.Get("name").String(), instanceName, "Memomystore instance has a valid id")
 		assert.Equal(memorySize, redis.Get("memorySizeGb").Int(), "Memorystore instance has been allocated 1 GB of memory")
+		assert.Equal(redis.Get("authEnabled").String(), "true", "Memoystore instance has auth enabled")
 		assert.Equal(redis.Get("connectMode").String(), "PRIVATE_SERVICE_ACCESS")
-		assert.Equal(redis.Get("redisVersion").String(), "REDIS_4_0")
+		assert.Equal(redis.Get("redisVersion").String(), "REDIS_7_0")
 	})
 
 	cloudRedisT.Test()


### PR DESCRIPTION
See [SIK-735.](https://enturas.atlassian.net/jira/software/projects/SIK/boards/214?selectedIssue=SIK-735)

This PR adds support for Redis authentication and updates the default Redis instance version to 7_0. As the first change is a breaking change forcing downtime, it made sense to also include the updated version change to avoid subsequent downtime in future updates. 

Authentication is currently provided as an optional setting that is set to false by default, but should be made non-optional or enabled by default in the future. This, after following-up the update with individual teams.

Added:
* Authentication to Redis
* Secret manager support
* Additional enable/disable settings for kubernetes and secret manager

Changes:
* Updated example to use newer init module
* Updated default Redis version to 7_0

Fixes:
* Changed accidental typo in ci pipeline
* Formatting of golang tests