### PR TITLE
fix!: Redis Authentication is now enforced

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -1,4 +1,3 @@
 skip-check:
   - CKV_TF_1    # Allow version not sha
   - CKV_GCP_97  # Intransit encryption not needed
-  - CKV_GCP_95  # in transition #todo

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,3 +13,4 @@ jobs:
       version_bumped_files: |
         README.md
         examples/minimal/main.tf
+        examples/minimal_custom_vpc/main.tf

--- a/examples/minimal_custom_vpc/main.tf
+++ b/examples/minimal_custom_vpc/main.tf
@@ -32,7 +32,8 @@ resource "google_compute_network" "redis_vpc_network" {
 
 # Redis module
 module "redis" {
-  source                      = "github.com/entur/terraform-google-memorystore//modules/redis?ref=v1.0.2"
+  #source                      = "github.com/entur/terraform-google-memorystore//modules/redis?ref=v1.0.2"
+  source                      = "../../modules/redis"
   init                        = module.init
   enable_auth                 = true
   create_kubernetes_resources = false
@@ -65,3 +66,14 @@ resource "google_vpc_access_connector" "redis_access_vpc_connector" {
     google_compute_global_address.redis_internal_vpc_address
   ]
 }
+
+# if needed, you can grant the app engine service account access to the redis secrets
+# Grant read rights to the redis secrets to the app engine service account
+# resource "google_secret_manager_secret_iam_member" "redis-secrets-member" {
+#   for_each   = toset(module.redis.secret_manager_secret_ids)
+#   project    = module.init.app.project_id
+#   secret_id  = each.key
+#   role       = "roles/secretmanager.secretAccessor"
+#   member     = "serviceAccount:${module.init.app.project_id}@appspot.gserviceaccount.com"
+#   depends_on = [module.redis]
+# }

--- a/examples/minimal_custom_vpc/main.tf
+++ b/examples/minimal_custom_vpc/main.tf
@@ -31,9 +31,9 @@ resource "google_compute_network" "redis_vpc_network" {
 }
 
 # Redis module
+# ci: x-release-please-start-version
 module "redis" {
-  #source                      = "github.com/entur/terraform-google-memorystore//modules/redis?ref=v1.0.2"
-  source                      = "../../modules/redis"
+  source                      = "github.com/entur/terraform-google-memorystore//modules/redis?ref=v1.0.2"
   init                        = module.init
   create_kubernetes_resources = false
   vpc_id                      = google_compute_network.redis_vpc_network.id
@@ -42,6 +42,7 @@ module "redis" {
     google_compute_network.redis_vpc_network
   ]
 }
+# ci: x-release-please-end
 
 # Create a internal address for the vpc access connector
 resource "google_compute_global_address" "redis_internal_vpc_address" {

--- a/examples/minimal_custom_vpc/main.tf
+++ b/examples/minimal_custom_vpc/main.tf
@@ -35,7 +35,6 @@ module "redis" {
   #source                      = "github.com/entur/terraform-google-memorystore//modules/redis?ref=v1.0.2"
   source                      = "../../modules/redis"
   init                        = module.init
-  enable_auth                 = true
   create_kubernetes_resources = false
   vpc_id                      = google_compute_network.redis_vpc_network.id
   depends_on = [

--- a/modules/redis/README.md
+++ b/modules/redis/README.md
@@ -60,7 +60,6 @@ No modules.
 | <a name="input_add_redis_secret_manager_credentials"></a> [add\_redis\_secret\_manager\_credentials](#input\_add\_redis\_secret\_manager\_credentials) | Set to false to not store redis credentials in secret manager | `bool` | `true` | no |
 | <a name="input_availability_type"></a> [availability\_type](#input\_availability\_type) | REGIONAL or ZONAL database. | `string` | `"REGIONAL"` | no |
 | <a name="input_create_kubernetes_resources"></a> [create\_kubernetes\_resources](#input\_create\_kubernetes\_resources) | Optionally disables creating k8s resources -redis-connection and -redis-secret. Can be used to avoid overwriting existing resources on database creation. | `bool` | `true` | no |
-| <a name="input_enable_auth"></a> [enable\_auth](#input\_enable\_auth) | Enable authentication | `bool` | `false` | no |
 | <a name="input_enable_replicas"></a> [enable\_replicas](#input\_enable\_replicas) | Enable read replicas | `bool` | `false` | no |
 | <a name="input_generation"></a> [generation](#input\_generation) | Generation of the redis instance. Starts at 1, ends at 999. Will be padded with leading zeros. | `number` | `1` | no |
 | <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The day of the week (MONDAY-SUNDAY), and hour of the day (0-24) in UTC to perform database instance maintenance. This is the start time of the one hour maintinance window. | <pre>object({<br>    day  = string<br>    hour = number<br>  })</pre> | <pre>{<br>  "day": "TUESDAY",<br>  "hour": 0<br>}</pre> | no |
@@ -81,4 +80,5 @@ No modules.
 | <a name="output_instance"></a> [instance](#output\_instance) | The redis instance output, as described in https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_instance. |
 | <a name="output_kubernetes_namespace"></a> [kubernetes\_namespace](#output\_kubernetes\_namespace) | Name of the kubernetes namespace where the connection details configmap is deployed. |
 | <a name="output_redis_password"></a> [redis\_password](#output\_redis\_password) | The auth password used to connect to the redis instance |
+| <a name="output_secret_manager_secret_ids"></a> [secret\_manager\_secret\_ids](#output\_secret\_manager\_secret\_ids) | n/a |
 <!-- END_TF_DOCS -->

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -18,7 +18,7 @@ resource "google_redis_instance" "main" {
 
   connect_mode       = var.vpc_id != null ? "DIRECT_PEERING" : "PRIVATE_SERVICE_ACCESS"
   authorized_network = var.vpc_id != null ? var.vpc_id : var.init.networks.vpc_id
-  auth_enabled       = var.enable_auth
+  auth_enabled       = true
   read_replicas_mode = var.enable_replicas ? "READ_REPLICAS_ENABLED" : "READ_REPLICAS_DISABLED"
   replica_count      = var.enable_replicas ? var.replica_count : null
 
@@ -53,7 +53,7 @@ locals {
 }
 locals {
   connection  = var.enable_replicas ? merge(local.primary_connection, local.read_connection) : local.primary_connection
-  credentials = var.enable_auth ? merge(local.connection, local.secret) : local.connection
+  credentials = merge(local.connection, local.secret)
 }
 
 resource "kubernetes_config_map" "main_redis_connection" {
@@ -67,7 +67,7 @@ resource "kubernetes_config_map" "main_redis_connection" {
 }
 
 resource "kubernetes_secret" "main_redis_secret" {
-  count = var.create_kubernetes_resources && var.enable_auth ? 1 : 0
+  count = var.create_kubernetes_resources ? 1 : 0
   metadata {
     name      = "${local.kubernetes_name}-redis-secret"
     namespace = var.init.app.name

--- a/modules/redis/outputs.tf
+++ b/modules/redis/outputs.tf
@@ -18,3 +18,7 @@ output "kubernetes_namespace" {
   description = "Name of the kubernetes namespace where the connection details configmap is deployed."
   value       = var.create_kubernetes_resources ? kubernetes_config_map.main_redis_connection[0].metadata[0].namespace : null
 }
+
+output "secret_manager_secret_ids" {
+  value = values(google_secret_manager_secret.main_redis_secret_credentials)[*].secret_id
+}

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -109,7 +109,7 @@ variable "replica_count" {
 variable "enable_auth" {
   description = "Enable authentication"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "secret_key_prefix" {

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -106,12 +106,6 @@ variable "replica_count" {
   }
 }
 
-variable "enable_auth" {
-  description = "Enable authentication"
-  type        = bool
-  default     = true
-}
-
 variable "secret_key_prefix" {
   description = "Key prefix of secret. Ex. {secret_key_prefix: FIRST_} would give keys FIRST_REDIS_HOST, FIRST_REDIS_PASSWORD and so on"
   type        = string

--- a/test/integration/redis_test.go
+++ b/test/integration/redis_test.go
@@ -26,12 +26,10 @@ func TestRedis(t *testing.T) {
 		instanceName := cloudRedisT.GetStringOutput("instance_name")
 		projectId := cloudRedisT.GetStringOutput("project_id")
 		redis := gcloud.Run(t, fmt.Sprintf("redis instances describe %s --project %s --region %s", instanceName, projectId, region))
-
 		assert.Contains(redis.Get("locationId").String(), region, "Memorystore instance's GCE region is valid")
 		assert.Contains(redis.Get("name").String(), instanceName, "Memomystore instance has a valid id")
 		assert.Equal(memorySize, redis.Get("memorySizeGb").Int(), "Memorystore instance has been allocated 1 GB of memory")
-		// Not applicable for current minimal_test
-		// assert.Equal(redis.Get("authEnabled").String(), "true", "Memoystore instance has auth enabled")
+		assert.Equal(redis.Get("authEnabled").String(), "true", "Memoystore instance has auth enabled")
 		assert.Equal(redis.Get("connectMode").String(), "PRIVATE_SERVICE_ACCESS")
 		assert.Equal(redis.Get("redisVersion").String(), "REDIS_7_0")
 	})


### PR DESCRIPTION
- [Breaking] Redis Authentication is no longer optional
    - Remove the "enable_auth" input flag
- Add outputs to show what secret ids is being created