### PR TITLE
Add integration tests for Valkey module

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           go-version-file: "test/integration/go.mod"
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: 1.9.8
           terraform_wrapper: false
@@ -34,7 +34,7 @@ jobs:
           gcp_service_account: ${{ vars.SERVICE_ACCOUNT }}
 
       - name: Kubernetes Auth
-        uses: entur/gha-meta/.github/actions/k8s-auth@v1
+        uses: entur/gha-meta/.github/actions/k8s-auth@v1 # NOSONAR
         with:
           environment: dev
 
@@ -61,21 +61,21 @@ jobs:
         with:
           go-version-file: "test/integration/go.mod"
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: 1.9.8
           terraform_wrapper: false
 
       - id: auth
         name: Cloud Auth
-        uses: entur/gha-meta/.github/actions/cloud-auth@v1
+        uses: entur/gha-meta/.github/actions/cloud-auth@v1 # NOSONAR
         with:
           environment: dev
           gcp_workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
           gcp_service_account: ${{ vars.SERVICE_ACCOUNT }}
 
       - name: Kubernetes Auth
-        uses: entur/gha-meta/.github/actions/k8s-auth@v1
+        uses: entur/gha-meta/.github/actions/k8s-auth@v1 # NOSONAR
         with:
           environment: dev
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,4 +44,45 @@ jobs:
 
       - name: Run Go Integration Tests
         working-directory: test/integration
-        run: go test -tags=integration -timeout 30m
+        run: go test -tags=integration -timeout 30m .
+
+  terratest_valkey:
+    permissions:
+      contents: "read"
+      id-token: "write"
+
+    name: Integration test Valkey module
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "test/integration/go.mod"
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.8
+          terraform_wrapper: false
+
+      - id: auth
+        name: Cloud Auth
+        uses: entur/gha-meta/.github/actions/cloud-auth@v1
+        with:
+          environment: dev
+          gcp_workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+          gcp_service_account: ${{ vars.SERVICE_ACCOUNT }}
+
+      - name: Kubernetes Auth
+        uses: entur/gha-meta/.github/actions/k8s-auth@v1
+        with:
+          environment: dev
+
+      - name: Download Go Modules
+        working-directory: test/integration
+        run: go mod download
+
+      - name: Run Go Integration Tests
+        working-directory: test/integration
+        run: go test -tags=integration -timeout 30m ./valkey/...

--- a/examples/minimal_valkey_test/main.tf
+++ b/examples/minimal_valkey_test/main.tf
@@ -10,8 +10,8 @@ module "init" {
   # make sure to use the latest release of the init module, found here:
   # https://github.com/entur/terraform-google-init/releases
   source      = "github.com/entur/terraform-google-init//modules/init?ref=v1.1.1"
-  app_id      = "rocketlnch"
-  environment = "sbx"
+  app_id      = "tfmodules"
+  environment = "dev"
 }
 
 module "valkey" {

--- a/examples/minimal_valkey_test/outputs.tf
+++ b/examples/minimal_valkey_test/outputs.tf
@@ -3,6 +3,11 @@ output "instance_name" {
   value       = module.valkey.instance.name
 }
 
+output "instance_id" {
+  description = "The short Valkey instance ID, used with gcloud."
+  value       = module.valkey.instance.instance_id
+}
+
 output "project_id" {
   description = "Project ID"
   value       = module.init.app.project_id

--- a/test/integration/valkey/valkey_test.go
+++ b/test/integration/valkey/valkey_test.go
@@ -1,0 +1,50 @@
+//go:build integration
+
+package valkey
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+	"github.com/stretchr/testify/assert"
+)
+
+const exampleDir = "../../../examples/minimal_valkey_test"
+
+func TestValkey(t *testing.T) {
+	const region = "europe-west1"
+	const engineVersion = "VALKEY_8_0"
+	const expectedShardCount int64 = 2
+	const expectedReplicaCount int64 = 1
+
+	cloudValkeyT := tft.NewTFBlueprintTest(t,
+		tft.WithTFDir(exampleDir),
+	)
+
+	cloudValkeyT.DefineVerify(func(assert *assert.Assertions) {
+		instanceId := cloudValkeyT.GetStringOutput("instance_id")
+		projectId := cloudValkeyT.GetStringOutput("project_id")
+
+		valkey := gcloud.Run(t, fmt.Sprintf("memorystore instances describe %s --location %s --project %s", instanceId, region, projectId))
+
+		assert.Contains(valkey.Get("name").String(), instanceId, "Memorystore Valkey instance has a valid id")
+		assert.Contains(valkey.Get("name").String(), region, "Memorystore Valkey instance is in the correct region")
+		assert.Equal(engineVersion, valkey.Get("engineVersion").String(), "Memorystore Valkey instance has correct engine version")
+		assert.Equal("CLUSTER", valkey.Get("mode").String(), "Memorystore Valkey instance is in cluster mode")
+		assert.Equal("IAM_AUTH", valkey.Get("authorizationMode").String(), "Memorystore Valkey instance has IAM authorization enabled")
+		assert.Equal("SERVER_AUTHENTICATION", valkey.Get("transitEncryptionMode").String(), "Memorystore Valkey instance has TLS enabled")
+		assert.Equal("STANDARD_SMALL", valkey.Get("nodeType").String(), "Memorystore Valkey instance has correct node type")
+		assert.Equal(expectedShardCount, valkey.Get("shardCount").Int(), "Memorystore Valkey instance has correct shard count")
+		assert.Equal(expectedReplicaCount, valkey.Get("replicaCount").Int(), "Memorystore Valkey instance has correct replica count")
+		assert.Equal("ACTIVE", valkey.Get("state").String(), "Memorystore Valkey instance is active")
+
+		for _, secretId := range []string{"VALKEY_HOST", "VALKEY_PORT", "CA"} {
+			secret := gcloud.Run(t, fmt.Sprintf("secrets describe %s --project %s", secretId, projectId))
+			assert.Contains(secret.Get("name").String(), secretId, "Secret %s exists in Secret Manager", secretId)
+		}
+	})
+
+	cloudValkeyT.Test()
+}


### PR DESCRIPTION
## Summary

- Adds `test/integration/valkey/valkey_test.go` — integration test for the Valkey module in its own `package valkey`, separate from the existing `redis` package
- Adds `instance_id` output to `examples/minimal_valkey_test/outputs.tf` so tests can pass the short instance ID to `gcloud memorystore instances describe`
- Adds `terratest_valkey` job to the integration test workflow, mirroring the Redis job; the Redis job is updated to explicitly target `.` so it never picks up the Valkey subdirectory

## Test plan

- [ ] Test asserts instance properties: name, region, engine version, mode, authorization mode, transit encryption mode, node type, shard count, replica count, state
- [ ] Test asserts all three Secret Manager secrets exist: `VALKEY_HOST`, `VALKEY_PORT`, `CA`
- [ ] Redis integration test job is unaffected (scoped to `.` not `./...`)
- [ ] Valkey integration test job runs on PR approval via the existing `pr-integration-tests.yml` trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)